### PR TITLE
Update footer copyright to 2026 and include build details

### DIFF
--- a/src/components/Footer/FooterBottom/Copyright/Copyright.tsx
+++ b/src/components/Footer/FooterBottom/Copyright/Copyright.tsx
@@ -4,7 +4,7 @@ import './Copyright.css'
 const Copyright: React.FC = () => {
   return (
     <div className="footer-bottom-right">
-      <p>© 2025 Aiden Cullo. All rights reserved. This site is hosted on GitHub Pages with a Namecheap domain.</p>
+      <p>© 2026 Aiden Cullo. All rights reserved. Built with React, TypeScript, and Vite, and hosted on GitHub Pages with a Namecheap domain.</p>
     </div>
   )
 }


### PR DESCRIPTION
### Motivation
- Keep the site footer accurate and transparent by updating the copyright year and stating how the site was built (tooling and hosting).  

### Description
- Replace the footer text in `src/components/Footer/FooterBottom/Copyright/Copyright.tsx` with: `© 2026 Aiden Cullo. All rights reserved. Built with React, TypeScript, and Vite, and hosted on GitHub Pages with a Namecheap domain.`

### Testing
- Ran `npm run build` which completed successfully (Vite production build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfe4eea6a08331a5a86930d6fc3710)